### PR TITLE
fixed cors error due to set v2 as module

### DIFF
--- a/src/lib/payjp-service.ts
+++ b/src/lib/payjp-service.ts
@@ -324,7 +324,6 @@ export class PayJpV2Service {
       const script = document.createElement('script');
       script.src = this.payJpV2Source;
       script.id = this.scriptId;
-      script.type = 'module';
 
       document.head.appendChild(script);
 


### PR DESCRIPTION
fixed cors error.

```typescript
script.type = 'module'; // removed this line in payjp-service
```